### PR TITLE
(RN0.40.0) Fixed ios native headers

### DIFF
--- a/src/ios/PushwooshPlugin/PWEventDispatcher.h
+++ b/src/ios/PushwooshPlugin/PWEventDispatcher.h
@@ -6,7 +6,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 
 @interface PWEventDispatcher : NSObject
 

--- a/src/ios/PushwooshPlugin/Pushwoosh.h
+++ b/src/ios/PushwooshPlugin/Pushwoosh.h
@@ -6,8 +6,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RCTBridgeModule.h"
-#import "RCTEventEmitter.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
 #import "PushNotificationManager.h"
 

--- a/src/ios/PushwooshPlugin/Pushwoosh.m
+++ b/src/ios/PushwooshPlugin/Pushwoosh.m
@@ -6,10 +6,10 @@
 
 #import "Pushwoosh.h"
 
-#import "RCTUtils.h"
-#import "RCTBridge.h"
+#import <React/RCTUtils.h>
+#import <React/RCTBridge.h>
 #import "PWEventDispatcher.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTEventDispatcher.h>
 
 static id objectOrNull(id object) {
 	if (!object) {


### PR DESCRIPTION
The import syntax has changed in react-native v0.40.0.
ref. https://github.com/facebook/react-native/releases/tag/v0.40.0

This PR follows new import syntax,
and need a major version bump for react-native 0.40. 

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pushwoosh/pushwoosh-react-native-plugin/9)
<!-- Reviewable:end -->
