### PR TITLE
fixed static react-native version and old package overwrite

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -40,7 +40,7 @@ ext {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.facebook.react:react-native:0.20.1'
+    compile 'com.facebook.react:react-native:+'
     compile "com.pushwoosh:pushwoosh:${pushwoosh}"
     compile "com.pushwoosh:pushwoosh-amazon:${pushwoosh}"
     compile "com.pushwoosh:pushwoosh-badge:${pushwoosh}"
@@ -59,3 +59,4 @@ dependencies {
     compile "com.google.firebase:firebase-core:+"
     compile "com.google.firebase:firebase-messaging:+"
 }
+

--- a/src/android/src/main/java/com/pushwoosh/reactnativeplugin/PushwooshPackage.java
+++ b/src/android/src/main/java/com/pushwoosh/reactnativeplugin/PushwooshPackage.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class PushwooshPackage implements ReactPackage {
-    @Override
+    // Deprecated from RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
@@ -32,3 +32,4 @@ public class PushwooshPackage implements ReactPackage {
         return modules;
     }
 }
+


### PR DESCRIPTION
This is a fix for #36 .
I replaced the static react-native version, that made it fail on newer react-native and gradle builds.

Also removed the @Overwrite on PushwooshPackage.java "createJSModules" that is deprecated since RN version 0.47