### PR TITLE
Support for custom iOS UNNotification handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ Pushwoosh.init({
 });
 Pushwoosh.register();
 ```
+
+In order to use custom notification handling on iOS specify the parameter "pw_notification_handling" to "CUSTOM" when initializing the plugin(If no value specified Pushwoosh notification handler is used):
+
+```js
+import Pushwoosh from 'pushwoosh-react-native-plugin';
+
+Pushwoosh.init({ 
+    "pw_appid" : "YOUR_PUSHWOOSH_PROJECT_ID" , 
+    "project_number" : "YOUR_GCM_PROJECT_NUMBER",
+    "pw_notification_handling" : "CUSTOM"
+});
+Pushwoosh.register();
+```

--- a/src/ios/PushwooshPlugin/Pushwoosh.m
+++ b/src/ios/PushwooshPlugin/Pushwoosh.m
@@ -43,7 +43,8 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(init:(NSDictionary*)config success:(RCTResponseSenderBlock)success error:(RCTResponseSenderBlock)error) {
 	NSString *appCode = config[@"pw_appid"];
-	
+    NSString *notificationHandling = config[@"pw_notification_handling"];
+    
 	if (!appCode || ![appCode isKindOfClass:[NSString class]]) {
 		if (error) {
 			error(@[ @"pw_appid is missing" ]);
@@ -51,12 +52,15 @@ RCT_EXPORT_METHOD(init:(NSDictionary*)config success:(RCTResponseSenderBlock)suc
 		
 		return;
 	}
-	
 	[PushNotificationManager initializeWithAppCode:appCode appName:nil];
 	[[PushNotificationManager pushManager] sendAppOpen];
 	[PushNotificationManager pushManager].delegate = self;
-	[UNUserNotificationCenter currentNotificationCenter].delegate = [PushNotificationManager pushManager].notificationCenterDelegate;
-	
+
+    // We set Pushwoosh UNUserNotificationCenter delegate unless CUSTOM is specified in the config
+    if(![notificationHandling isEqualToString:@"CUSTOM"]) {
+        [UNUserNotificationCenter currentNotificationCenter].delegate = [PushNotificationManager pushManager].notificationCenterDelegate;
+    }
+
     if (success) {
         success(@[]);
     }


### PR DESCRIPTION
This PR adds a support for users to add their custom UNNotificationCenter delegate for iOS as discussed here https://github.com/Pushwoosh/pushwoosh-react-native-plugin/issues . 
Approach used in this PR was extending the config with a new parameter. The default behaviour would be to use Pushwoosh delegate