### PR TITLE
Specify iOS SDK version in podspec

### DIFF
--- a/pushwoosh-react-native-plugin.podspec
+++ b/pushwoosh-react-native-plugin.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'React'
-  s.dependency 'Pushwoosh'
+  s.dependency 'Pushwoosh', '6.1.0'
   s.dependency 'PushwooshInboxUI'
 end


### PR DESCRIPTION
Specify iOS SDK version in podspec so that RN would not make a version mismatch on iOS.

ref: https://github.com/Pushwoosh/pushwoosh-react-native-plugin/issues/105
